### PR TITLE
Fix custom reducer delegation across multiple stepper instances

### DIFF
--- a/.changeset/curly-mugs-pull.md
+++ b/.changeset/curly-mugs-pull.md
@@ -1,0 +1,5 @@
+---
+"use-stepper": patch
+---
+
+Fix custom reducer delegation across multiple stepper instances. Previously, multiple instances would erroneously share whichever default reducer was assigned by the most recently rendered instance.

--- a/src/__tests__/use-stepper.test.tsx
+++ b/src/__tests__/use-stepper.test.tsx
@@ -304,6 +304,36 @@ describe("useStepper", () => {
     expect(result.current.value).toBe("0");
   });
 
+  it("delegates to the instance default reducer from a custom reducer", () => {
+    function delegateReducer(state: State, action: Action) {
+      return useStepper.defaultReducer(state, action);
+    }
+
+    const { result } = renderHook(() => useStepper({ step: 5, stateReducer: delegateReducer }));
+
+    act(() => result.current.increment());
+    expect(result.current.value).toBe("5");
+  });
+
+  it("delegates to the matching instance default reducer with multiple steppers", () => {
+    function delegateReducer(state: State, action: Action) {
+      return useStepper.defaultReducer(state, action);
+    }
+
+    const { result } = renderHook(() => ({
+      byTwo: useStepper({ step: 2, stateReducer: delegateReducer }),
+      byFive: useStepper({ step: 5, stateReducer: delegateReducer }),
+    }));
+
+    act(() => result.current.byTwo.increment());
+    expect(result.current.byTwo.value).toBe("2");
+    expect(result.current.byFive.value).toBe("0");
+
+    act(() => result.current.byFive.increment());
+    expect(result.current.byTwo.value).toBe("2");
+    expect(result.current.byFive.value).toBe("5");
+  });
+
   describe("enableReinitialize", () => {
     it("true: value is updated to new default if defaultValue changes and value has not been modified", () => {
       const { result, rerender } = renderHook((opts) => useStepper(opts), {

--- a/src/use-stepper.ts
+++ b/src/use-stepper.ts
@@ -11,6 +11,13 @@ const actionTypes = {
   setValue: "setValue",
 };
 
+const defaultOptions = {
+  defaultValue: 0,
+  step: 1,
+  min: -Number.MAX_VALUE,
+  max: Number.MAX_VALUE,
+};
+
 export interface State {
   value: string;
 }
@@ -58,15 +65,92 @@ export interface UseStepper {
   defaultReducer: (state: State, action: Action) => State;
 }
 
-// @ts-expect-error (`actionTypes` and `defaultReducer` are added at invocation time)
-export const useStepper: UseStepper = ({
-  defaultValue = 0,
-  step = 1,
-  min = -Number.MAX_VALUE,
-  max = Number.MAX_VALUE,
+function getDefaultReducer({
+  defaultValue,
+  step,
+  min,
+  max,
+}: Pick<Required<Options>, "defaultValue" | "step" | "min" | "max">) {
+  const validValueClosestTo = (newValue: number | string) => {
+    const newValueNum = typeof newValue === "number" ? newValue : Number.parseFloat(newValue);
+    return String(Math.min(max, Math.max(newValueNum, min)));
+  };
+
+  return (state: State, action: Action): State => {
+    const currentNumericValue = Number.parseFloat(state.value);
+    switch (action.type) {
+      case actionTypes.increment: {
+        const newValue = validValueClosestTo(sum(currentNumericValue, step));
+        if (newValue !== state.value) {
+          return { value: newValue };
+        }
+        return state;
+      }
+      case actionTypes.decrement: {
+        const newValue = validValueClosestTo(sum(currentNumericValue, -step));
+        if (newValue !== state.value) {
+          return { value: newValue };
+        }
+        return state;
+      }
+      case actionTypes.coerce: {
+        if (Number.isNaN(currentNumericValue)) {
+          return { value: String(defaultValue) };
+        }
+        const newValue = validValueClosestTo(currentNumericValue);
+        if (newValue !== state.value) {
+          return { value: newValue };
+        }
+        return state;
+      }
+      case actionTypes.setValue: {
+        if (action.payload !== undefined && action.payload !== state.value) {
+          return { value: action.payload };
+        }
+        return state;
+      }
+      /* v8 ignore next -- @preserve */
+      default: {
+        throw new Error(`Unsupported action type: ${action.type}`);
+      }
+    }
+  };
+}
+
+const fallbackDefaultReducer = getDefaultReducer(defaultOptions);
+let activeDefaultReducer = fallbackDefaultReducer;
+
+function defaultReducer(state: State, action: Action): State {
+  return activeDefaultReducer(state, action);
+}
+
+function getReducer(
+  userReducer: Options["stateReducer"],
+  instanceDefaultReducer: (state: State, action: Action) => State,
+) {
+  if (userReducer === undefined) {
+    return instanceDefaultReducer;
+  }
+
+  return (state: State, action: Action): State => {
+    const previousDefaultReducer = activeDefaultReducer;
+    activeDefaultReducer = instanceDefaultReducer;
+    try {
+      return userReducer(state, action);
+    } finally {
+      activeDefaultReducer = previousDefaultReducer;
+    }
+  };
+}
+
+const useStepperFunction = ({
+  defaultValue = defaultOptions.defaultValue,
+  step = defaultOptions.step,
+  min = defaultOptions.min,
+  max = defaultOptions.max,
   enableReinitialize = false,
   stateReducer: userReducer,
-} = {}) => {
+}: Options = {}) => {
   const previousDefaultValue = usePrevious(defaultValue);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -80,54 +164,17 @@ export const useStepper: UseStepper = ({
 
   const initialState: State = { value: String(defaultValue) };
 
-  const defaultReducer = React.useCallback(
-    (state: State, action: Action): State => {
-      const currentNumericValue = Number.parseFloat(state.value);
-      switch (action.type) {
-        case actionTypes.increment: {
-          const newValue = validValueClosestTo(sum(currentNumericValue, step));
-          if (newValue !== state.value) {
-            return { value: newValue };
-          }
-          return state;
-        }
-        case actionTypes.decrement: {
-          const newValue = validValueClosestTo(sum(currentNumericValue, -step));
-          if (newValue !== state.value) {
-            return { value: newValue };
-          }
-          return state;
-        }
-        case actionTypes.coerce: {
-          if (Number.isNaN(currentNumericValue)) {
-            return { value: String(defaultValue) };
-          }
-          const newValue = validValueClosestTo(currentNumericValue);
-          if (newValue !== state.value) {
-            return { value: newValue };
-          }
-          return state;
-        }
-        case actionTypes.setValue: {
-          if (action.payload !== undefined && action.payload !== state.value) {
-            return { value: action.payload };
-          }
-          return state;
-        }
-        /* v8 ignore next -- @preserve */
-        default: {
-          throw new Error(`Unsupported action type: ${action.type}`);
-        }
-      }
-    },
-    [validValueClosestTo, defaultValue, step],
+  const instanceDefaultReducer = React.useMemo(
+    () => getDefaultReducer({ defaultValue, step, min, max }),
+    [defaultValue, step, min, max],
   );
 
-  // Expose our internal/default reducer and action types
-  useStepper.defaultReducer = defaultReducer;
-  useStepper.actionTypes = actionTypes;
+  const reducer = React.useMemo(
+    () => getReducer(userReducer, instanceDefaultReducer),
+    [userReducer, instanceDefaultReducer],
+  );
 
-  const [{ value }, dispatch] = React.useReducer(userReducer || defaultReducer, initialState);
+  const [{ value }, dispatch] = React.useReducer(reducer, initialState);
 
   const setValue = React.useCallback((newValue: string) => {
     dispatch({
@@ -290,3 +337,8 @@ export const useStepper: UseStepper = ({
     getDecrementProps,
   };
 };
+
+export const useStepper: UseStepper = Object.assign(useStepperFunction, {
+  actionTypes,
+  defaultReducer,
+});


### PR DESCRIPTION
This pull request fixes an issue with the `useStepper` hook where custom reducers could incorrectly share the default reducer across multiple stepper instances, leading to unexpected behavior. The implementation now ensures that each instance uses its own default reducer, even when custom reducers delegate to it. The changes also improve the way default options are handled and add comprehensive tests for the new behavior.

Key fixes and improvements:

**Bug Fixes & Core Logic:**
* Ensured that custom reducer delegation works correctly across multiple `useStepper` instances, so each instance uses its own default reducer and does not interfere with others. [[1]](diffhunk://#diff-74c7418918c96840ee6b17f375076186f34c7bcc02823faeb575daed1a312d35R1-R5) [[2]](diffhunk://#diff-2fea1f1e80c84ef1ab84f6a4948e54368ddc46f56c9398f421d2e0a1d0fb6ee4R117-R177)
* Refactored the default reducer logic to be instance-specific by introducing `getDefaultReducer`, `getReducer`, and an internal mechanism to track the active default reducer per instance. [[1]](diffhunk://#diff-2fea1f1e80c84ef1ab84f6a4948e54368ddc46f56c9398f421d2e0a1d0fb6ee4R117-R177) [[2]](diffhunk://#diff-2fea1f1e80c84ef1ab84f6a4948e54368ddc46f56c9398f421d2e0a1d0fb6ee4L61-R79)

**API & Defaults:**
* Centralized default option values in a new `defaultOptions` object, simplifying default value management for the hook.

**Testing:**
* Added new tests to verify that custom reducers correctly delegate to the instance-specific default reducer, both for single and multiple stepper instances.

**Exports & Type Safety:**
* Updated the export of `useStepper` to include `actionTypes` and `defaultReducer` as properties, preserving the previous API surface while using the new implementation.